### PR TITLE
Checking collision with Environment layer

### DIFF
--- a/Rigidbody Throw.prefab
+++ b/Rigidbody Throw.prefab
@@ -9093,7 +9093,7 @@ ParticleSystem:
     radiusScale: 1
     collidesWith:
       serializedVersion: 2
-      m_Bits: 21
+      m_Bits: 2069
     maxCollisionShapes: 256
     quality: 0
     voxelSize: 0.5

--- a/Rotation-Synced/Rigidbody Throw.prefab
+++ b/Rotation-Synced/Rigidbody Throw.prefab
@@ -10454,7 +10454,7 @@ ParticleSystem:
     radiusScale: 1
     collidesWith:
       serializedVersion: 2
-      m_Bits: 21
+      m_Bits: 2069
     maxCollisionShapes: 256
     quality: 0
     voxelSize: 0.5


### PR DESCRIPTION
From: #10 

Based on my testing, a lot of worlds like to use the Environment layer, which the Rigidbody Throw package should check collision for, as this layer is mainly used for the environment and nothing else.

Other than that, this also adds compatibility with this Udon prefab: [UdonPlayerPlatformHook](https://github.com/Superbstingray/UdonPlayerPlatformHook), which allows players to be moved and rotated with moving and rotating platforms that they stand on.

This prefab (by default) requires the world's creator to mark moving platforms with the Environment layer, to make the prefab work.